### PR TITLE
api response 연동 등등

### DIFF
--- a/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/controller/StoreController.java
+++ b/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/controller/StoreController.java
@@ -1,6 +1,8 @@
 package com.DreamCoder.DreamLeaf.controller;
 
 
+import com.DreamCoder.DreamLeaf.dto.DetailStoreDto;
+import com.DreamCoder.DreamLeaf.dto.SimpleStoreDto;
 import com.DreamCoder.DreamLeaf.dto.StoreDto;
 import com.DreamCoder.DreamLeaf.req.UserCurReq;
 import com.DreamCoder.DreamLeaf.service.StoreService;
@@ -39,17 +41,17 @@ public class StoreController {
     }
 
     @GetMapping("/{storeId}")
-    public Optional<StoreDto> showStoreDetail(@PathVariable int storeId){
+    public Optional<DetailStoreDto> showStoreDetail(@PathVariable int storeId){
         return storeService.findById(storeId);
     }
 
     @PostMapping("/findByKeyword")
-    public List<StoreDto> findByKeyword(@RequestParam String keyword, @RequestBody UserCurReq userCurReq){       //거리 순으로 정렬
+    public List<SimpleStoreDto> findByKeyword(@RequestParam String keyword, @RequestBody UserCurReq userCurReq){       //거리 순으로 정렬
         return storeService.findByKeyword(keyword, userCurReq);
     }
 
     @PostMapping("/findByCur")
-    public List<StoreDto> findByCur(@RequestBody UserCurReq userCurReq){
+    public List<SimpleStoreDto> findByCur(@RequestBody UserCurReq userCurReq){
         return storeService.findByCur(userCurReq);
     }
 

--- a/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/controller/StoreController.java
+++ b/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/controller/StoreController.java
@@ -2,23 +2,15 @@ package com.DreamCoder.DreamLeaf.controller;
 
 
 import com.DreamCoder.DreamLeaf.dto.StoreDto;
-import com.DreamCoder.DreamLeaf.req.StoreReq;
 import com.DreamCoder.DreamLeaf.req.UserCurReq;
 import com.DreamCoder.DreamLeaf.service.StoreService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.json.simple.JSONArray;
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.util.NumberUtils;
 import org.springframework.web.bind.annotation.*;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
-import java.net.URL;
 import java.util.List;
 import java.util.Optional;
 
@@ -31,88 +23,16 @@ public class StoreController {
     @Autowired
     private final StoreService storeService;
 
+
 //    @PostMapping("/save")    //for test
 //    public ResponseEntity save(@RequestBody StoreReq storeReq){
 //        return ResponseEntity.status(HttpStatus.CREATED).body(storeService.create(storeReq));
 //    }
 
     @PostMapping("/api")
-    public ResponseEntity saveGDreamCardApi(){
-        String result="";
-        try{
-            URL url=new URL("https://openapi.gg.go.kr/GDreamCard?KEY=e67be2abc4464ffcb547fe1fecc6d138&Type=json");
-            BufferedReader bf;
-            bf=new BufferedReader(new InputStreamReader(url.openStream(), "UTF-8"));
-            result=bf.readLine();
+    public ResponseEntity saveApi(){
 
-
-            JSONParser jsonParser=new JSONParser();
-            JSONObject jsonObject=(JSONObject) jsonParser.parse(result);
-            JSONArray gDreamCard=(JSONArray) jsonObject.get("GDreamCard");      //전체 json get(size=2(head, row))
-
-            //casting head
-            JSONObject head=(JSONObject)gDreamCard.get(0);
-            JSONArray head2=(JSONArray)head.get("head");
-            log.info("head={}", head2);
-            Long totalCnt=(Long)((JSONObject)head2.get(0)).get("list_total_count");
-            log.info("cnt={}", totalCnt);
-            JSONObject apiResult=(JSONObject)((JSONObject)head2.get(1)).get("RESULT");
-            String resultCode=(String)apiResult.get("CODE");
-            log.info("resCode={}", resultCode);
-
-            //casting body(row)
-            JSONObject row=(JSONObject)gDreamCard.get(1);
-            JSONArray infoArr=(JSONArray)row.get("row");
-
-
-
-            for(int i=0;i<infoArr.size();i++){
-                JSONObject temp=(JSONObject)infoArr.get(i);
-
-                //check zip, location if null
-                int zipcd;
-                double lat, logt;
-                String lotno;
-
-                if((String)temp.get("REFINE_LOTNO_ADDR")==null){
-                    lotno="";
-                }
-                else{
-                    lotno=(String)temp.get("REFINE_LOTNO_ADDR");
-                }
-                if((String)temp.get("REFINE_ZIP_CD")==null){
-                    zipcd=0;
-                }
-                else{
-                    zipcd=Integer.parseInt((String)temp.get("REFINE_ZIP_CD"));
-                }
-                if((String)temp.get("REFINE_WGS84_LAT")==null){
-                    lat=0;
-                }
-                else{
-                    lat=Double.parseDouble((String)temp.get("REFINE_WGS84_LAT"));
-                }
-                if((String)temp.get("REFINE_WGS84_LOGT")==null){
-                    logt=0;
-                }
-                else{
-                    logt=Double.parseDouble((String)temp.get("REFINE_WGS84_LOGT"));
-                }
-
-
-                StoreReq infoObj=new StoreReq((String)temp.get("FACLT_NM"),
-                        zipcd,
-                        (String)temp.get("REFINE_ROADNM_ADDR"),
-                        lotno,
-                        lat, logt,true, null, null);
-                storeService.save(infoObj);
-            }
-
-
-
-        }catch(Exception e){
-            e.printStackTrace();
-        }
+        storeService.saveApi();
 
         return ResponseEntity.status(HttpStatus.CREATED).body("");
 

--- a/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/dto/DetailStoreDto.java
+++ b/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/dto/DetailStoreDto.java
@@ -1,0 +1,26 @@
+package com.DreamCoder.DreamLeaf.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.ToString;
+
+@Data
+@AllArgsConstructor
+@ToString
+@Builder
+public class DetailStoreDto {
+    private int storeId;            //store 고유 id
+    private String storeName;       //store 이름
+    private int storeType;          //카드가맹점 or(and) 선한영향력가게
+    private String hygieneGrade;     //위생등급
+    private int refinezipCd;            //우편번호
+    private String refineRoadnmAddr;        //도로명주소
+    private String refineLotnoAddr;         //지번주소
+    private double refineWGS84Lat;        //위도
+    private double refineWGS84Logt;       //경도
+    private double curDist;         //현재 위치로부터의 거리
+    private String prodName;        //제공품목
+    private String prodTarget;      //제공대상
+    private double totalRating;     //평균 리뷰점수
+}

--- a/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/dto/SimpleStoreDto.java
+++ b/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/dto/SimpleStoreDto.java
@@ -1,0 +1,19 @@
+package com.DreamCoder.DreamLeaf.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.ToString;
+
+@Data
+@AllArgsConstructor
+@ToString
+@Builder
+public class SimpleStoreDto {
+    private int storeId;
+    private String storeName;
+    private int storeType;
+    private double curDist;
+    private double totalRating;
+}

--- a/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/dto/StoreDto.java
+++ b/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/dto/StoreDto.java
@@ -9,12 +9,15 @@ import lombok.*;
 public class StoreDto {
     private int storeId;            //store 고유 id
     private String storeName;       //store 이름
+    private int payment;          //카드가맹점 or(and) 선한영향력가게
+    //private String hygieneGrade;     //위생등급
     private int zipCode;            //우편번호
     private String roadAddr;
     private String lotAddr;
     private double wgs84Lat;
     private double wgs84Logt;
-    private boolean payment;
+    //private double curDist;
     private String prodName;
     private String prodTarget;
+    //private double totalRating;
 }

--- a/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/dto/StoreDto.java
+++ b/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/dto/StoreDto.java
@@ -9,15 +9,15 @@ import lombok.*;
 public class StoreDto {
     private int storeId;            //store 고유 id
     private String storeName;       //store 이름
-    private int payment;          //카드가맹점 or(and) 선한영향력가게
-    //private String hygieneGrade;     //위생등급
+    private String hygieneGrade;     //위생등급
     private int zipCode;            //우편번호
     private String roadAddr;
     private String lotAddr;
     private double wgs84Lat;
     private double wgs84Logt;
-    //private double curDist;
+//    private double curDist;
+    private int payment;          //카드가맹점 or(and) 선한영향력가게
     private String prodName;
     private String prodTarget;
-    //private double totalRating;
+//    private double totalRating;
 }

--- a/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/repository/StoreRepository.java
+++ b/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/repository/StoreRepository.java
@@ -1,5 +1,7 @@
 package com.DreamCoder.DreamLeaf.repository;
 
+import com.DreamCoder.DreamLeaf.dto.DetailStoreDto;
+import com.DreamCoder.DreamLeaf.dto.SimpleStoreDto;
 import com.DreamCoder.DreamLeaf.dto.StoreDto;
 import com.DreamCoder.DreamLeaf.req.StoreReq;
 import com.DreamCoder.DreamLeaf.req.UserCurReq;
@@ -9,9 +11,9 @@ import java.util.Optional;
 
 public interface StoreRepository {
     public Optional<StoreDto> save(StoreReq storeReq);
-    public Optional<StoreDto> findById(int id);
-    public List<StoreDto> findByKeyword(String keyword, UserCurReq userCurReq);       //사용자로부터의 거리 순으로 정렬
-    public List<StoreDto> findByCur(UserCurReq userCurReq);
+    public Optional<DetailStoreDto> findById(int id);
+    public List<SimpleStoreDto> findByKeyword(String keyword, UserCurReq userCurReq);       //사용자로부터의 거리 순으로 정렬
+    public List<SimpleStoreDto> findByCur(UserCurReq userCurReq);
 
     Boolean hasAnotherType(StoreReq forCheck);
 

--- a/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/repository/StoreRepository.java
+++ b/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/repository/StoreRepository.java
@@ -8,8 +8,12 @@ import java.util.List;
 import java.util.Optional;
 
 public interface StoreRepository {
-    public StoreDto save(StoreReq storeReq);
+    public Optional<StoreDto> save(StoreReq storeReq);
     public Optional<StoreDto> findById(int id);
     public List<StoreDto> findByKeyword(String keyword, UserCurReq userCurReq);       //사용자로부터의 거리 순으로 정렬
     public List<StoreDto> findByCur(UserCurReq userCurReq);
+
+    Boolean hasAnotherType(StoreReq forCheck);
+
+    public void updatePaymentTo2(StoreReq storeReq);
 }

--- a/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/repository/StoreRepositoryImpl.java
+++ b/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/repository/StoreRepositoryImpl.java
@@ -1,5 +1,7 @@
 package com.DreamCoder.DreamLeaf.repository;
 
+import com.DreamCoder.DreamLeaf.dto.DetailStoreDto;
+import com.DreamCoder.DreamLeaf.dto.SimpleStoreDto;
 import com.DreamCoder.DreamLeaf.dto.StoreDto;
 import com.DreamCoder.DreamLeaf.req.StoreReq;
 import com.DreamCoder.DreamLeaf.req.UserCurReq;
@@ -92,11 +94,11 @@ public class StoreRepositoryImpl implements StoreRepository{
     }
 
     @Override
-    public Optional<StoreDto> findById(int storeId) {
+    public Optional<DetailStoreDto> findById(int storeId) {
         String sql="select * from store where storeId=?";
         try{
-            StoreDto storeDto = template.queryForObject(sql, storeDtoRowMapper, storeId);
-            return Optional.of(storeDto);
+            DetailStoreDto result = template.queryForObject(sql, detailStoreDtoRowMapper, storeId);
+            return Optional.of(result);
         }catch(EmptyResultDataAccessException e){
             return Optional.empty();
         }
@@ -104,20 +106,20 @@ public class StoreRepositoryImpl implements StoreRepository{
     }
 
     @Override
-    public List<StoreDto> findByKeyword(String keyword, UserCurReq userCurReq) {
+    public List<SimpleStoreDto> findByKeyword(String keyword, UserCurReq userCurReq) {
         String sql="select *, (6371*acos(cos(radians(?))*cos(radians(wgs84Lat))*cos(radians(wgs84Logt)" +
                 "-radians(?))+sin(radians(?))*sin(radians(wgs84Lat))))" +
                 "AS distance from store where storeName like ? order by distance";
         log.info("lat={}, logt={}", userCurReq.getCurLat(), userCurReq.getCurLogt());
-        return template.query(sql, storeDtoRowMapper, userCurReq.getCurLat(), userCurReq.getCurLogt(), userCurReq.getCurLat(),"%"+keyword+"%");
+        return template.query(sql, simpleStoreDtoRowMapper, userCurReq.getCurLat(), userCurReq.getCurLogt(), userCurReq.getCurLat(),"%"+keyword+"%");
     }
 
     @Override
-    public List<StoreDto> findByCur(UserCurReq userCurReq) {
+    public List<SimpleStoreDto> findByCur(UserCurReq userCurReq) {
         String sql="select *, (6371*acos(cos(radians(?))*cos(radians(wgs84Lat))*cos(radians(wgs84Logt)" +
                 "-radians(?))+sin(radians(?))*sin(radians(wgs84Lat))))" +
                 "AS distance from store having distance<2 order by distance";
-        return template.query(sql, storeDtoRowMapper, userCurReq.getCurLat(), userCurReq.getCurLogt(), userCurReq.getCurLat());
+        return template.query(sql, simpleStoreDtoRowMapper, userCurReq.getCurLat(), userCurReq.getCurLogt(), userCurReq.getCurLat());
     }
 
 
@@ -126,17 +128,43 @@ public class StoreRepositoryImpl implements StoreRepository{
             StoreDto.builder()
                     .storeId(rs.getInt("storeId"))
                     .storeName(rs.getString("storeName"))
-                    //.hygieneGrade("매우우수(임시)")
+                    .hygieneGrade("매우우수(임시)")
                     .zipCode(rs.getInt("zipCode"))
                     .roadAddr(rs.getString("roadAddr"))
                     .lotAddr(rs.getString("lotAddr"))
                     .wgs84Lat(rs.getDouble("wgs84Lat"))
                     .wgs84Logt(rs.getDouble("wgs84Logt"))
-                    //.curDist(0.0)
-                    .payment(rs.getInt("payment"))
+//                    .curDist(0.0)
+                    .payment(rs.getInt("payment"))          //->storeType(rs.getInt("payment")
                     .prodName(rs.getString("prodName"))
                     .prodTarget(rs.getString("prodTarget"))
-                    //.totalRating(5.0)
+//                    .totalRating(5.0)
+                    .build();
+
+    private RowMapper<SimpleStoreDto> simpleStoreDtoRowMapper=(rs, rowNum)->
+            SimpleStoreDto.builder()
+                    .storeId(rs.getInt("storeId"))
+                    .storeName(rs.getString("storeName"))
+                    .storeType(rs.getInt("payment"))
+                    .curDist(0.0)                   //만들기
+                    .totalRating(5.0)               //만들기
+                    .build();
+
+    private RowMapper<DetailStoreDto> detailStoreDtoRowMapper=(rs, rowNum)->
+            DetailStoreDto.builder()
+                    .storeId(rs.getInt("storeId"))
+                    .storeName(rs.getString("storeName"))
+                    .hygieneGrade("매우우수(임시)")
+                    .refinezipCd(rs.getInt("zipCode"))
+                    .refineRoadnmAddr(rs.getString("roadAddr"))
+                    .refineLotnoAddr(rs.getString("lotAddr"))
+                    .refineWGS84Lat(rs.getDouble("wgs84Lat"))
+                    .refineWGS84Logt(rs.getDouble("wgs84Logt"))
+                    .curDist(0.0)
+                    .storeType(rs.getInt("payment"))          //->storeType(rs.getInt("payment")
+                    .prodName(rs.getString("prodName"))
+                    .prodTarget(rs.getString("prodTarget"))
+                    .totalRating(5.0)
                     .build();
 
 

--- a/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/repository/StoreRepositoryImpl.java
+++ b/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/repository/StoreRepositoryImpl.java
@@ -24,8 +24,21 @@ public class StoreRepositoryImpl implements StoreRepository{
 
 
     @Override
-    @Transactional
-    public StoreDto save(StoreReq storeReq) {
+    @Transactional(rollbackFor = Exception.class)
+    public Optional<StoreDto> save(StoreReq storeReq) {
+
+        //음식점명, 위경도가 동일한 데이터가 있는지 확인
+        String checkSql="select * from store where storeName=? and wgs84Lat=? and wgs84Logt=?";
+        List<StoreDto> checkForDuplicate=template.query(checkSql, storeDtoRowMapper,
+                storeReq.getStoreName(),
+                storeReq.getWgs84Lat(),
+                storeReq.getWgs84Logt());
+        if(checkForDuplicate.size()>0){
+            log.info("no insert={}", storeReq.getStoreName());
+            return Optional.empty();
+        }
+
+
         String sql="insert into store(storeName, zipCode, roadAddr, lotAddr, wgs84Lat, wgs84Logt, payment, prodName, prodTarget) values(?, ?, ?, ?, ?, ?, ?, ?, ?)";
         template.update(sql,
                 storeReq.getStoreName(),
@@ -34,12 +47,50 @@ public class StoreRepositoryImpl implements StoreRepository{
                 storeReq.getLotAddr(),
                 storeReq.getWgs84Lat(),
                 storeReq.getWgs84Logt(),
-                storeReq.isPayment(),
+                storeReq.getPayment(),
                 storeReq.getProdName(),
                 storeReq.getProdTarget());
-        String resultSql="select * from store where roadAddr=?";       //수정 필요
-        return template.queryForObject(resultSql, storeDtoRowMapper, storeReq.getRoadAddr());
+
+        String resultSql="select * from store where storeName=? and zipCode=? and roadAddr=? and lotAddr=? and wgs84Lat=? and wgs84Logt=? and payment=? and prodName=? and prodTarget=?";
+        return Optional.of(template.queryForObject(resultSql, storeDtoRowMapper, storeReq.getStoreName(),
+                storeReq.getZipCode(),
+                storeReq.getRoadAddr(),
+                storeReq.getLotAddr(),
+                storeReq.getWgs84Lat(),
+                storeReq.getWgs84Logt(),
+                storeReq.getPayment(),
+                storeReq.getProdName(),
+                storeReq.getProdTarget()));
     }
+    @Override
+    public Boolean hasAnotherType(StoreReq forCheck){
+        String resultSql="select * from store where storeName=? and wgs84Lat=? and wgs84Logt=? and payment=?";
+        List<StoreDto> temp=template.query(resultSql, storeDtoRowMapper,
+                forCheck.getStoreName(),
+                forCheck.getWgs84Lat(),
+                forCheck.getWgs84Logt(),
+                forCheck.getPayment());
+        if(temp.size()>0){
+            for(int i=0;i<temp.size();i++){
+                log.info("i={} storeName={}, resName={}, lat={}, logt={}, payment={}",i, forCheck.getStoreName(),temp.get(i).getStoreName(), forCheck.getWgs84Lat(), forCheck.getWgs84Logt(), forCheck.getPayment());
+            }
+            return true;
+        }else{
+            return false;
+        }
+    }
+
+    @Override
+    public void updatePaymentTo2(StoreReq storeReq) {
+        String sql="update store set payment=2 where storeName=? and wgs84Lat=? and wgs84Logt=? and payment=?";
+        template.update(sql,
+                storeReq.getStoreName(),
+                storeReq.getWgs84Lat(),
+                storeReq.getWgs84Logt(),
+                storeReq.getPayment());
+
+    }
+
     @Override
     public Optional<StoreDto> findById(int storeId) {
         String sql="select * from store where storeId=?";
@@ -69,18 +120,23 @@ public class StoreRepositoryImpl implements StoreRepository{
         return template.query(sql, storeDtoRowMapper, userCurReq.getCurLat(), userCurReq.getCurLogt(), userCurReq.getCurLat());
     }
 
+
+
     private RowMapper<StoreDto> storeDtoRowMapper=(rs, rowNum) ->
             StoreDto.builder()
                     .storeId(rs.getInt("storeId"))
                     .storeName(rs.getString("storeName"))
+                    //.hygieneGrade("매우우수(임시)")
                     .zipCode(rs.getInt("zipCode"))
                     .roadAddr(rs.getString("roadAddr"))
                     .lotAddr(rs.getString("lotAddr"))
                     .wgs84Lat(rs.getDouble("wgs84Lat"))
                     .wgs84Logt(rs.getDouble("wgs84Logt"))
-                    .payment(rs.getBoolean("payment"))
+                    //.curDist(0.0)
+                    .payment(rs.getInt("payment"))
                     .prodName(rs.getString("prodName"))
                     .prodTarget(rs.getString("prodTarget"))
+                    //.totalRating(5.0)
                     .build();
 
 

--- a/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/req/StoreReq.java
+++ b/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/req/StoreReq.java
@@ -16,7 +16,7 @@ public class StoreReq {
     private String lotAddr;         //지번주소
     private double wgs84Lat;        //위도
     private double wgs84Logt;       //경도
-    private boolean payment;        //아동급식카드 지원여부
+    private int payment;        //아동급식카드 지원여부
     private String prodName;        //제공품목
     private String prodTarget;      //제공대상
 }

--- a/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/service/ApiManager.java
+++ b/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/service/ApiManager.java
@@ -1,0 +1,265 @@
+package com.DreamCoder.DreamLeaf.service;
+
+
+import com.DreamCoder.DreamLeaf.repository.StoreRepository;
+import com.DreamCoder.DreamLeaf.req.StoreReq;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.URL;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ApiManager {
+
+    @Autowired
+    private final StoreRepository storeRepository;
+
+    private String makeUrl(String storeType, String key, String dataType, int pIndex, int pSize){
+        StringBuffer sb=new StringBuffer();
+        sb.append("https://openapi.gg.go.kr/");
+        sb.append(storeType);
+        sb.append("?KEY=");
+        sb.append(key);
+        sb.append("&Type=");
+        sb.append(dataType);
+        sb.append("&pIndex=");
+        sb.append(pIndex);
+        sb.append("&pSize=");
+        sb.append(pSize);
+
+        return sb.toString();
+    }
+
+    public void saveGDreamCardApi(){
+        String result="";
+        int pIndex=1;
+        Long totalCnt;
+        try{
+            do{
+            URL url=new URL(makeUrl("GDreamCard", "e67be2abc4464ffcb547fe1fecc6d138","json", pIndex, 1000));
+            BufferedReader bf;
+            bf=new BufferedReader(new InputStreamReader(url.openStream(), "UTF-8"));
+            result=bf.readLine();
+
+
+            JSONParser jsonParser=new JSONParser();
+            JSONObject jsonObject=(JSONObject) jsonParser.parse(result);
+            JSONArray gDreamCard=(JSONArray) jsonObject.get("GDreamCard");      //전체 json get(size=2(head, row))
+
+            //casting head
+            JSONObject head=(JSONObject)gDreamCard.get(0);
+            JSONArray head2=(JSONArray)head.get("head");
+            log.info("head={}", head2);
+            totalCnt=(Long)((JSONObject)head2.get(0)).get("list_total_count");
+            log.info("cnt={}", totalCnt);
+            JSONObject apiResult=(JSONObject)((JSONObject)head2.get(1)).get("RESULT");
+            String resultCode=(String)apiResult.get("CODE");
+            log.info("resCode={}", resultCode);
+
+            //casting body(row)
+            JSONObject row=(JSONObject)gDreamCard.get(1);
+            JSONArray infoArr=(JSONArray)row.get("row");
+
+
+
+            for(int i=0;i<infoArr.size();i++) {
+                JSONObject temp = (JSONObject) infoArr.get(i);
+
+                //check zip, location if null
+                int zipcd;
+                double lat, logt;
+                String lotno;
+
+                if ((String) temp.get("REFINE_LOTNO_ADDR") == null) {
+                    lotno = "";
+                } else {
+                    lotno = (String) temp.get("REFINE_LOTNO_ADDR");
+                }
+                if ((String) temp.get("REFINE_ZIP_CD") == null) {
+                    zipcd = 0;
+                } else {
+                    zipcd = Integer.parseInt((String) temp.get("REFINE_ZIP_CD"));
+                }
+                if ((String) temp.get("REFINE_WGS84_LAT") == null) {
+                    continue;
+                } else {
+                    lat = Double.parseDouble((String) temp.get("REFINE_WGS84_LAT"));
+                }
+                if ((String) temp.get("REFINE_WGS84_LOGT") == null) {
+                    continue;
+                } else {
+                    logt = Double.parseDouble((String) temp.get("REFINE_WGS84_LOGT"));
+                }
+
+                StoreReq checkFor1=new StoreReq((String) temp.get("FACLT_NM"),
+                        zipcd,
+                        (String) temp.get("REFINE_ROADNM_ADDR"),
+                        lotno,
+                        lat, logt, 0, "", "");
+                StoreReq checkFor2=new StoreReq((String) temp.get("FACLT_NM"),
+                        zipcd,
+                        (String) temp.get("REFINE_ROADNM_ADDR"),
+                        lotno,
+                        lat, logt, 2, "", "");
+                if(storeRepository.hasAnotherType(checkFor1)){
+                    storeRepository.updatePaymentTo2(checkFor1);
+                }
+                else if(storeRepository.hasAnotherType(checkFor2)){
+
+                }
+                else{
+                    StoreReq infoObj = new StoreReq((String) temp.get("FACLT_NM"),
+                            zipcd,
+                            (String) temp.get("REFINE_ROADNM_ADDR"),
+                            lotno,
+                            lat, logt, 1, "", "");
+                    storeRepository.save(infoObj);
+                }
+            }
+            pIndex++;
+            }while(pIndex<=(totalCnt/1000)+1);
+
+
+
+        }catch(Exception e){
+            e.printStackTrace();
+        }
+    }
+
+    public void saveGoodStoreApi(){
+        String result="";
+        int pIndex=1;
+        Long totalCnt;
+        try{
+            do{
+                URL url=new URL(makeUrl("GGGOODINFLSTOREST", "fb1025fa7b1145fbbbc2a843c0d8c10e","json", pIndex, 1000));
+                BufferedReader bf;
+                bf=new BufferedReader(new InputStreamReader(url.openStream(), "UTF-8"));
+                result=bf.readLine();
+
+
+                JSONParser jsonParser=new JSONParser();
+                JSONObject jsonObject=(JSONObject) jsonParser.parse(result);
+                JSONArray goodStore=(JSONArray) jsonObject.get("GGGOODINFLSTOREST");      //전체 json get(size=2(head, row))
+
+                //casting head
+                JSONObject head=(JSONObject)goodStore.get(0);
+                JSONArray head2=(JSONArray)head.get("head");
+                log.info("head={}", head2);
+                totalCnt=(Long)((JSONObject)head2.get(0)).get("list_total_count");
+                log.info("cnt={}", totalCnt);
+                JSONObject apiResult=(JSONObject)((JSONObject)head2.get(1)).get("RESULT");
+                String resultCode=(String)apiResult.get("CODE");
+                log.info("resCode={}", resultCode);
+
+                //casting body(row)
+                JSONObject row=(JSONObject)goodStore.get(1);
+                JSONArray infoArr=(JSONArray)row.get("row");
+
+
+
+                for(int i=0;i<infoArr.size();i++){
+                    JSONObject temp=(JSONObject)infoArr.get(i);
+
+                    //check zip, location if null
+                    int zipcd;
+                    double lat, logt;
+                    String roadno,lotno,prodName, prodTarget;
+
+                    //음식점이 아닌 가게는 추가하지 않음
+                    if(!((String)temp.get("INDUTYPE_NM")).equals("식음료")){
+                        continue;
+                    }
+
+                    //정보가 없는 가게에 대한 String 처리
+                    if((String)temp.get("REFINE_ROADNM_ADDR")==null){
+                        roadno="";
+                    }
+                    else{
+                        roadno=(String)temp.get("REFINE_ROADNM_ADDR");
+                    }
+                    if((String)temp.get("REFINE_LOTNO_ADDR")==null){
+                        lotno="";
+                    }
+                    else{
+                        lotno=(String)temp.get("REFINE_LOTNO_ADDR");
+                    }
+                    if((String)temp.get("REFINE_ZIP_CD")==null){
+                        zipcd=0;
+                    }
+                    else{
+                        zipcd=Integer.parseInt((String)temp.get("REFINE_ZIP_CD"));
+                    }
+
+                    //위치 정보가 없는 가게는 추가하지 않음
+                    if((String)temp.get("REFINE_WGS84_LAT")==null){
+                        continue;
+                    }
+                    else{
+                        lat=Double.parseDouble((String)temp.get("REFINE_WGS84_LAT"));
+                    }
+                    if((String)temp.get("REFINE_WGS84_LOGT")==null){
+                        continue;
+                    }
+                    else{
+                        logt=Double.parseDouble((String)temp.get("REFINE_WGS84_LOGT"));
+                    }
+                    if((String)temp.get("PROVSN_PRODLST_NM")==null){
+                        prodName="";
+                    }
+                    else{
+                        prodName=(String)temp.get("PROVSN_PRODLST_NM");
+                    }
+                    if((String)temp.get("PROVSN_TRGT_NM1")==null){
+                        prodTarget="";
+                    }
+                    else{
+                        prodTarget=(String)temp.get("PROVSN_TRGT_NM1");
+                    }
+                    if((String)temp.get("PROVSN_TRGT_NM2")!=null){
+                        prodTarget+=(String)temp.get("PROVSN_TRGT_NM2");
+                    }
+
+                    StoreReq checkFor1=new StoreReq((String)temp.get("CMPNM_NM"),
+                            zipcd,
+                            roadno,
+                            lotno,
+                            lat, logt,1, prodName, prodTarget);
+                    StoreReq checkFor2=new StoreReq((String)temp.get("CMPNM_NM"),
+                            zipcd,
+                            roadno,
+                            lotno,
+                            lat, logt,2, prodName, prodTarget);
+                    if(storeRepository.hasAnotherType(checkFor1)){
+                        storeRepository.updatePaymentTo2(checkFor1);
+                    }
+                    else if(storeRepository.hasAnotherType(checkFor2)){
+
+                    }
+                    else{
+                        StoreReq infoObj=new StoreReq((String)temp.get("CMPNM_NM"),
+                                zipcd,
+                                roadno,
+                                lotno,
+                                lat, logt,0, prodName, prodTarget);
+                        storeRepository.save(infoObj);
+                    }
+                }
+                pIndex++;
+            }while(pIndex<=(totalCnt/1000)+1);
+        }catch(Exception e){
+            e.printStackTrace();
+        }
+
+    }
+
+}

--- a/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/service/ApiManager.java
+++ b/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/service/ApiManager.java
@@ -193,11 +193,11 @@ public class ApiManager {
                     else{
                         lotno=(String)temp.get("REFINE_LOTNO_ADDR");
                     }
-                    if((String)temp.get("REFINE_ZIP_CD")==null){
+                    if((String)temp.get("REFINE_ZIPNO")==null){
                         zipcd=0;
                     }
                     else{
-                        zipcd=Integer.parseInt((String)temp.get("REFINE_ZIP_CD"));
+                        zipcd=Integer.parseInt((String)temp.get("REFINE_ZIPNO"));
                     }
 
                     //위치 정보가 없는 가게는 추가하지 않음

--- a/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/service/StoreService.java
+++ b/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/service/StoreService.java
@@ -19,10 +19,10 @@ public class StoreService {
 
     @Autowired
     private final StoreRepository storeRepository;
+    private final ApiManager apiManager;
 
 
-
-    public StoreDto save(StoreReq storeReq){
+    public Optional<StoreDto> save(StoreReq storeReq){
         return storeRepository.save(storeReq);
     }
 
@@ -36,6 +36,11 @@ public class StoreService {
 
     public List<StoreDto> findByCur(UserCurReq userCurReq){           //클라이언트에게 위치 정보를 받아서 거리 계산
         return storeRepository.findByCur(userCurReq);
+    }
+
+    public void saveApi(){
+        apiManager.saveGoodStoreApi();
+        apiManager.saveGDreamCardApi();
     }
 
 

--- a/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/service/StoreService.java
+++ b/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/service/StoreService.java
@@ -1,5 +1,7 @@
 package com.DreamCoder.DreamLeaf.service;
 
+import com.DreamCoder.DreamLeaf.dto.DetailStoreDto;
+import com.DreamCoder.DreamLeaf.dto.SimpleStoreDto;
 import com.DreamCoder.DreamLeaf.dto.StoreDto;
 import com.DreamCoder.DreamLeaf.repository.StoreRepository;
 import com.DreamCoder.DreamLeaf.req.StoreReq;
@@ -26,15 +28,15 @@ public class StoreService {
         return storeRepository.save(storeReq);
     }
 
-    public Optional<StoreDto> findById(int storeId){
+    public Optional<DetailStoreDto> findById(int storeId){
         return storeRepository.findById(storeId);
     }
 
-    public List<StoreDto> findByKeyword(String keyword, UserCurReq userCurReq){
+    public List<SimpleStoreDto> findByKeyword(String keyword, UserCurReq userCurReq){
         return storeRepository.findByKeyword(keyword, userCurReq);
     }
 
-    public List<StoreDto> findByCur(UserCurReq userCurReq){           //클라이언트에게 위치 정보를 받아서 거리 계산
+    public List<SimpleStoreDto> findByCur(UserCurReq userCurReq){           //클라이언트에게 위치 정보를 받아서 거리 계산
         return storeRepository.findByCur(userCurReq);
     }
 


### PR DESCRIPTION
선한영향력가게, 카드가맹점의 모든 데이터를 가져오도록 수정
  -두 데이터의 합병은 부분 구현(가게이름, 위경도가 같은 경우를 같은 가게인 것으로 처리)
  -부분구현에서 생기는 문제점은 추후 수정 예정
response 전송 부분 수정
  -키워드,위치 검색은 ui 기준으로 필요한 정보만 보내도록 작성
  -상세정보는 모든 정보를 보내도록 작성
    -거리 정보, 별점, 위생등급은 미구현(각각 5.0, 0.0, 매우우수(임시)로 임시 작성)
  -api문서 미수정(추후 수정예정)