### PR TITLE
가게 병합 알고리즘 추가

### DIFF
--- a/Backend/aDreamLeaf/build.gradle
+++ b/Backend/aDreamLeaf/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1'
+	implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/controller/StoreController.java
+++ b/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/controller/StoreController.java
@@ -48,6 +48,8 @@ public class StoreController {
         return storeService.findByCur(userCurReq);
     }
 
+
+
 }
 
 

--- a/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/repository/StoreRepository.java
+++ b/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/repository/StoreRepository.java
@@ -20,4 +20,6 @@ public interface StoreRepository {
     Boolean hasAnotherType(StoreReq forCheck);
 
     public void updatePaymentTo2(StoreReq storeReq);
+
+    public void checkAndMerge();
 }

--- a/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/repository/StoreRepositoryImpl.java
+++ b/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/repository/StoreRepositoryImpl.java
@@ -213,7 +213,7 @@ public class StoreRepositoryImpl implements StoreRepository{
 
     @Builder
     @Data
-    public static class CheckSameStore{
+    static class CheckSameStore{
         private String aStore;
         private String bStore;
         private double wgs84Lat;

--- a/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/service/StoreService.java
+++ b/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/service/StoreService.java
@@ -61,10 +61,10 @@ public class StoreService {
     }
 
     public void saveApi(){
-//        apiManager.saveGoodStoreApi();
-//        apiManager.saveGDreamCardApi();
+        apiManager.saveGoodStoreApi();
+        apiManager.saveGDreamCardApi();
         storeRepository.checkAndMerge();
-//        apiManager.saveHygieneApi();
+        apiManager.saveHygieneApi();
     }
 
 

--- a/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/service/StoreService.java
+++ b/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/service/StoreService.java
@@ -63,6 +63,7 @@ public class StoreService {
     public void saveApi(){
         apiManager.saveGoodStoreApi();
         apiManager.saveGDreamCardApi();
+        storeRepository.checkAndMerge();
         apiManager.saveHygieneApi();
     }
 

--- a/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/service/StoreService.java
+++ b/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/service/StoreService.java
@@ -61,10 +61,10 @@ public class StoreService {
     }
 
     public void saveApi(){
-        apiManager.saveGoodStoreApi();
-        apiManager.saveGDreamCardApi();
+//        apiManager.saveGoodStoreApi();
+//        apiManager.saveGDreamCardApi();
         storeRepository.checkAndMerge();
-        apiManager.saveHygieneApi();
+//        apiManager.saveHygieneApi();
     }
 
 


### PR DESCRIPTION
카드가맹점과 선한영향력가게중 이름이 비슷하여 다르게 인식되었으나 실제로는 같은 가게를 같은 가게로 인식하는 알고리즘 추가
    -Levenshtein distance 알고리즘 사용(threshold=0.7로 설정)
    -예외 케이스는 Map에 넣어서 처리