### PR TITLE
위생등급 처리

### DIFF
--- a/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/repository/StoreRepository.java
+++ b/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/repository/StoreRepository.java
@@ -5,6 +5,7 @@ import com.DreamCoder.DreamLeaf.dto.SimpleStoreDto;
 import com.DreamCoder.DreamLeaf.dto.StoreDto;
 import com.DreamCoder.DreamLeaf.req.StoreReq;
 import com.DreamCoder.DreamLeaf.req.UserCurReq;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -22,4 +23,7 @@ public interface StoreRepository {
     public void updatePaymentTo2(StoreReq storeReq);
 
     public void checkAndMerge();
+
+    @Transactional(rollbackFor = Exception.class)
+    void mergeStore(StoreRepositoryImpl.CheckSameStore s);
 }

--- a/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/repository/StoreRepositoryImpl.java
+++ b/Backend/aDreamLeaf/src/main/java/com/DreamCoder/DreamLeaf/repository/StoreRepositoryImpl.java
@@ -194,7 +194,6 @@ public class StoreRepositoryImpl implements StoreRepository{
                 Map.entry("돌체도노", "돌체도노(Dolce dono)")
         );
 
-
         if(findSimilarity(s.getAStore(), s.getBStore())>=0.7){
             return true;
         }
@@ -204,11 +203,85 @@ public class StoreRepositoryImpl implements StoreRepository{
         return false;
     }
 
-    private void mergeStore(CheckSameStore s){
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public void mergeStore(CheckSameStore s){
         String usql="update store set payment=2 where storeName=? and wgs84Lat=? and wgs84Logt=?";
         template.update(usql, s.getAStore(), s.getWgs84Lat(), s.getWgs84Logt());
         String dsql="delete from store where storeName=? and wgs84Lat=? and wgs84Logt=?";
         template.update(dsql, s.getBStore(), s.getWgs84Lat(), s.getWgs84Logt());
+    }
+
+    public String checkHygrade(String storeName, double wgs84Lat, double wgs84Logt){
+        String checkSql="select a.storeName, a.grade, a.wgs84Lat, a.wgs84Logt from storeHygrade as a where wgs84Lat=? and wgs84Logt=?";
+        List<CheckSameStoreHygrade> res=template.query(checkSql, checkSameStoreHygradeRowMapper, wgs84Lat, wgs84Logt);
+        Map<String, String> degenerateCase2=Map.ofEntries(
+                Map.entry("스트릿츄러스 롯데몰수원점","스트릿츄러스수원롯데몰"),
+                Map.entry("땡초불닭발동대문엽기떡볶이","불닭발땡초동대문엽기떡볶이"),
+                Map.entry("곡간 수제도시락","곡간"),
+                Map.entry("빅빅버거 다산본점","빅빅버거"),
+                Map.entry("파스타입니다-고양시청점","파스타입니다"),
+                Map.entry("피자이탈리 구래점","피자이탈리(pizza italy) 구래점"),
+                Map.entry("비에이치씨(BHC)화도창현점","BHC 화도창현점"),
+                Map.entry("비에이치씨(bhc)다산중앙점","bhc 다산중앙점"),
+                Map.entry("비에이치씨 덕풍점","bhc(비에이치씨) 덕풍점"),
+                Map.entry("비에이치씨(BHC) 동탄방교점","BHC 동탄방교점"),
+                Map.entry("(주)케이에프씨코리아 KFC일산후곡","케이에프씨(KFC) 일산후곡"),
+                Map.entry("(주)현대그린푸드 h가든 테이크호텔","에이치가든테이크호텔점"),
+                Map.entry("비에이치씨 김포양곡점","bhc김포양곡점"),
+                Map.entry("비에이치씨(bhc)일산가좌점","bhc 일산가좌점"),
+                Map.entry("비에치씨(BHC)용인송전점","(B.H.C)비에이치씨 용인송전점"),
+                Map.entry("한국맥도날드 (유) 행신점","한국맥도날드행신점"),
+                Map.entry("비알코리아(주)던킨도너츠 남양주호평","던킨도너츠 남양주호평점"),
+                Map.entry("(주)피자알볼로 동탄","주식회사 피자알볼로동탄"),
+                Map.entry("더제이케이키친박스","더제이케이키친박스(The JK KitchenBox)"),
+                Map.entry("한국맥도날드 유한회사 행신점","한국맥도날드행신점"),
+                Map.entry("(주)파리크라상 쉐이크쉑 AK분당플라자","쉐이크쉑 AK분당플라자점"),
+                Map.entry("지에스25 용인한숲점","(주)지에스리테일GS수퍼용인한숲시티점"),
+                Map.entry("비에이치씨(BHC)백석역점","BHC백석역점"),
+                Map.entry("일미리금계찜닭","일미리금계찜닭배곧신도시점"),
+                Map.entry("비비큐(BBQ) 매탄행복점","BBQ 매탄행복점"),
+                Map.entry("비에이치씨(BHC) 부발점","BHC부발점"),
+                Map.entry("본죽&까페비빔밥오산수청점","본죽오산수청점"),
+                Map.entry("비에이치씨(BHC) 성대율전점","BHC성대율전점"),
+                Map.entry("맥도날드부천원종DT점","한국맥도날드(유) 부천원종DT점"),
+                Map.entry("비에이치씨치킨 부천괴안점","BHC치킨부천괴안점"),
+                Map.entry("가유카페","가유카페 광교상현점"),
+                Map.entry("비에이치씨(BHC)분당무지개점","BHC 분당무지개점"),
+                Map.entry("비에이치씨 우만점","BHC 우만점"),
+                Map.entry("교촌치킨 사동1호점","교촌치킨(사1동점)"),
+                Map.entry("투썸플레이스 서판교점","투썸플레이스(Two Some Place) 서판교점"),
+                Map.entry("비에이치씨(BHC)치킨 (석수중앙점)","비에이치씨치킨 석수중앙점"),
+                Map.entry("버거킹 분당차병원점/(주)비케이알","버거킹 분당차병원점"),
+                Map.entry("비에이치씨(BHC)곡반아이파크시티","비에이치시곡반아이파크시티(BHC곡반아이파크시티)"),
+                Map.entry("파스쿠찌 죽전(서울방향)휴게소점","죽전(서울방향)휴게소 파스쿠찌"),
+                Map.entry("비에이치씨(BHC)안중점","BHC평택안중점"),
+                Map.entry("지에스(GS)25 진위힐스점","지에스25진위힐스점"),
+                Map.entry("주식회사 카페티움","카페티움 주식회사"),
+                Map.entry("VIPS중동소풍점/씨제이푸드빌(주)","씨제이푸드빌(주)빕스 중동소풍점"),
+                Map.entry("지에스(GS)25 용인모현점","지에스25용인모현점"),
+                Map.entry("비에이치씨(bhc) 치킨 서판교점","BHC 치킨 서판교점"),
+                Map.entry("(비에이치씨)BHC호계융창점","BHC 호계융창점")
+        );
+        for(CheckSameStoreHygrade store:res){
+            if(findSimilarity(storeName, store.getStoreName())>=0.7){
+                Map<String, String> degenearateCase1=Map.ofEntries(
+                        Map.entry("빽다방 별내파라곤스퀘어점", "더벤티 별내파라곤스퀘어점"),
+                        Map.entry("아비꼬 판교파미어스몰점", "이디야 판교파미어스몰점")
+                );
+                if(degenearateCase1.get(storeName)!=null && degenearateCase1.get(storeName).equals(store.getStoreName())){      //높은 편집거리의 다른 가게 걸러내기
+                    return "";
+                }
+                return store.getGrade();
+            }
+            else if (degenerateCase2.get(storeName)!=null && degenerateCase2.get(storeName).equals(store.getStoreName())){      //낮은 편집거리의 같은 가게 위생등급 적용하기
+                return store.getGrade();
+            }
+
+        }
+
+        return "";
+
     }
 
     @Builder
@@ -216,6 +289,15 @@ public class StoreRepositoryImpl implements StoreRepository{
     static class CheckSameStore{
         private String aStore;
         private String bStore;
+        private double wgs84Lat;
+        private double wgs84Logt;
+    }
+
+    @Builder
+    @Data
+    static class CheckSameStoreHygrade{
+        private String storeName;
+        private String grade;
         private double wgs84Lat;
         private double wgs84Logt;
     }
@@ -252,7 +334,7 @@ public class StoreRepositoryImpl implements StoreRepository{
             DetailStoreDto.builder()
                     .storeId(rs.getInt("storeId"))
                     .storeName(rs.getString("storeName"))
-                    .hygieneGrade("매우우수")
+                    .hygieneGrade(checkHygrade(rs.getString("storeName"), rs.getDouble("wgs84Lat"), rs.getDouble("wgs84Logt")))
                     .refinezipCd(rs.getInt("zipCode"))
                     .refineRoadnmAddr(rs.getString("roadAddr"))
                     .refineLotnoAddr(rs.getString("lotAddr"))
@@ -268,6 +350,14 @@ public class StoreRepositoryImpl implements StoreRepository{
             CheckSameStore.builder()
                     .aStore(rs.getString("aStore"))
                     .bStore(rs.getString("bStore"))
+                    .wgs84Lat(rs.getDouble("wgs84Lat"))
+                    .wgs84Logt(rs.getDouble("wgs84Logt"))
+                    .build();
+
+    private RowMapper<CheckSameStoreHygrade> checkSameStoreHygradeRowMapper=(rs, rowNum)->
+            CheckSameStoreHygrade.builder()
+                    .storeName(rs.getString("storeName"))
+                    .grade(rs.getString("grade"))
                     .wgs84Lat(rs.getDouble("wgs84Lat"))
                     .wgs84Logt(rs.getDouble("wgs84Logt"))
                     .build();


### PR DESCRIPTION
가게 상세정보에서 위생등급을 확인할 수 있도록 구현
    -가게 병합시와 마찬가지로 Levenshtein Distance Algorithm 사용(threshold=0.7)
    -높은 편집거리의 다른 가게인 경우 처리(2)
    -낮은 편집거리의 같은 가게인 경우 처리(46)
    -위생등급 정보가 존재하지 않을 경우 빈 스트링("")을 전송하도록 처리